### PR TITLE
Hide tags on expanded roster unit cards

### DIFF
--- a/packages/web/src/components/shared/roster/roster-unit-card-base.tsx
+++ b/packages/web/src/components/shared/roster/roster-unit-card-base.tsx
@@ -9,9 +9,16 @@ interface RosterUnitCardBaseProps {
   actions?: ReactNode;
   children?: ReactNode;
   onClick?: () => void;
+  showTags?: boolean;
 }
 
-const RosterUnitCardBase: FC<RosterUnitCardBaseProps> = ({ unit, actions, children, onClick }) => {
+const RosterUnitCardBase: FC<RosterUnitCardBaseProps> = ({
+  unit,
+  actions,
+  children,
+  onClick,
+  showTags = true
+}) => {
   const unitPoints = parseInt(unit.modelCost.cost, 10) || 0;
 
   const inlineAbilities = useMemo(() => {
@@ -40,8 +47,8 @@ const RosterUnitCardBase: FC<RosterUnitCardBaseProps> = ({ unit, actions, childr
         <PointsTag points={unitPoints} className="whitespace-nowrap" />
       </div>
 
-      {(inlineAbilities.length > 0 || unit.selectedWargear.length > 0) && (
-        <TagGroup spacing="sm">
+      {showTags && (inlineAbilities.length > 0 || unit.selectedWargear.length > 0) && (
+        <TagGroup spacing="sm" data-testid="roster-unit-tags">
           {inlineAbilities.map((ability, index) => (
             <Tag key={`ability-${index}`} variant="primary" size="sm">
               {ability.name}

--- a/packages/web/src/pages/view-roster/components/view-roster-unit-card.test.tsx
+++ b/packages/web/src/pages/view-roster/components/view-roster-unit-card.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { TestWrapper } from '@/test/test-utils';
+import { createMockRosterUnit, createMockDatasheet, mockDatasheet } from '@/test/mock-data';
+import ViewRosterUnitCard from './view-roster-unit-card';
+
+describe('ViewRosterUnitCard', () => {
+  it('toggles tag visibility when expanded', () => {
+    const datasheetWithInlineAbility = createMockDatasheet({
+      abilities: [
+        ...mockDatasheet.abilities,
+        {
+          id: 'shock-assault',
+          name: 'Shock Assault',
+          legend: '',
+          factionId: 'SM',
+          description: 'Test inline ability',
+          type: 'Datasheet'
+        }
+      ]
+    });
+
+    const unit = createMockRosterUnit({
+      datasheet: datasheetWithInlineAbility,
+      modelCost: datasheetWithInlineAbility.modelCosts[0],
+      selectedWargear: [
+        {
+          ...mockDatasheet.wargear[0],
+          name: 'Relic Blade'
+        }
+      ]
+    });
+
+    render(<ViewRosterUnitCard unit={unit} />, { wrapper: TestWrapper });
+
+    expect(screen.getByTestId('roster-unit-tags')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('heading', { name: unit.datasheet.name }));
+
+    expect(screen.queryByTestId('roster-unit-tags')).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/pages/view-roster/components/view-roster-unit-card.tsx
+++ b/packages/web/src/pages/view-roster/components/view-roster-unit-card.tsx
@@ -18,7 +18,12 @@ const ViewRosterUnitCard: React.FC<ViewRosterUnitCardProps> = ({ unit }) => {
   );
 
   return (
-    <RosterUnitCardBase unit={unit} actions={actions} onClick={() => setIsExpanded(!isExpanded)}>
+    <RosterUnitCardBase
+      unit={unit}
+      actions={actions}
+      onClick={() => setIsExpanded(!isExpanded)}
+      showTags={!isExpanded}
+    >
       {isExpanded && <UnitDetails unit={unit} />}
     </RosterUnitCardBase>
   );


### PR DESCRIPTION
## Summary
- add a `showTags` toggle to `RosterUnitCardBase` so tag rendering can be controlled
- hide roster unit tags when view-mode cards are expanded and expose a test id for assertions
- add a regression test covering the tag visibility toggle in view roster cards

## Testing
- pnpm format
- pnpm typecheck
- pnpm --filter @depot/web test -- --run --reporter verbose

------
https://chatgpt.com/codex/tasks/task_e_68e15595e2dc8326b46dbcc382dac2fc