### PR TITLE
Render transport capacity and leader attachments on datasheets

### DIFF
--- a/packages/web/src/components/shared/datasheet/datasheet-composition.tsx
+++ b/packages/web/src/components/shared/datasheet/datasheet-composition.tsx
@@ -7,12 +7,14 @@ import { Card } from '@/components/ui';
 interface DatasheetCompositionProps {
   composition: depot.UnitComposition[];
   loadout: string;
+  transport?: string;
   'data-testid'?: string;
 }
 
 export const DatasheetComposition: FC<DatasheetCompositionProps> = ({
   composition,
   loadout,
+  transport,
   'data-testid': testId
 }) => (
   <Card className="flex flex-col gap-2 p-4" data-testid={testId}>
@@ -25,9 +27,18 @@ export const DatasheetComposition: FC<DatasheetCompositionProps> = ({
         />
       ))}
     </ul>
-    <p
-      className="text-sm text-gray-700 dark:text-gray-300"
-      dangerouslySetInnerHTML={{ __html: loadout }}
-    />
+    {loadout?.trim() ? (
+      <p
+        className="text-sm text-gray-700 dark:text-gray-300"
+        dangerouslySetInnerHTML={{ __html: loadout }}
+      />
+    ) : null}
+    {transport?.trim() ? (
+      <p
+        className="text-sm text-gray-700 dark:text-gray-300"
+        dangerouslySetInnerHTML={{ __html: transport }}
+        data-testid="transport-capacity"
+      />
+    ) : null}
   </Card>
 );

--- a/packages/web/src/pages/datasheet/components/datasheet-hero.tsx
+++ b/packages/web/src/pages/datasheet/components/datasheet-hero.tsx
@@ -13,7 +13,7 @@ interface DatasheetHeroProps {
 }
 
 const DatasheetHero: FC<DatasheetHeroProps> = ({ datasheet }) => {
-  const { models, keywords, unitComposition, loadout } = datasheet;
+  const { models, keywords, unitComposition, loadout, transport } = datasheet;
   const groupedKeywords = groupKeywords(keywords);
 
   if (models.length === 0) return null;
@@ -28,6 +28,7 @@ const DatasheetHero: FC<DatasheetHeroProps> = ({ datasheet }) => {
       <DatasheetComposition
         composition={unitComposition}
         loadout={loadout}
+        transport={transport}
         data-testid="unit-composition"
       />
 

--- a/packages/web/src/pages/datasheet/components/datasheet-leader-rules.test.tsx
+++ b/packages/web/src/pages/datasheet/components/datasheet-leader-rules.test.tsx
@@ -74,10 +74,7 @@ describe('DatasheetLeaderRules', () => {
 
     render(
       <MemoryRouter>
-        <DatasheetLeaderRules
-          datasheet={leaderDatasheet}
-          factionDatasheets={[leaderDatasheet]}
-        />
+        <DatasheetLeaderRules datasheet={leaderDatasheet} factionDatasheets={[leaderDatasheet]} />
       </MemoryRouter>
     );
 

--- a/packages/web/src/pages/datasheet/components/datasheet-leader-rules.test.tsx
+++ b/packages/web/src/pages/datasheet/components/datasheet-leader-rules.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+import { createMockDatasheet } from '@/test/mock-data';
+import DatasheetLeaderRules from './datasheet-leader-rules';
+
+describe('DatasheetLeaderRules', () => {
+  it('does not render when no leader information is available', () => {
+    const datasheet = createMockDatasheet({
+      leaderHead: '',
+      leaderFooter: '',
+      leaders: []
+    });
+
+    render(
+      <MemoryRouter>
+        <DatasheetLeaderRules datasheet={datasheet} factionDatasheets={[datasheet]} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByTestId('datasheet-leader-rules')).not.toBeInTheDocument();
+  });
+
+  it('renders leader head, linked units, and footer when provided', () => {
+    const targetDatasheet = createMockDatasheet({
+      id: 'intercessors',
+      slug: 'intercessor-squad',
+      name: 'Intercessor Squad'
+    });
+
+    const leaderDatasheet = createMockDatasheet({
+      leaderHead: '<p>This model can be attached to one of the following units:</p>',
+      leaderFooter: '<p>While attached, this model shares their fate.</p>',
+      leaders: [
+        {
+          id: 'intercessors',
+          slug: 'intercessor-squad'
+        }
+      ]
+    });
+
+    render(
+      <MemoryRouter>
+        <DatasheetLeaderRules
+          datasheet={leaderDatasheet}
+          factionDatasheets={[leaderDatasheet, targetDatasheet]}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('datasheet-leader-rules')).toBeInTheDocument();
+    expect(
+      screen.getByText('This model can be attached to one of the following units:')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Intercessor Squad' })).toHaveAttribute(
+      'href',
+      '/faction/space-marines/datasheet/intercessor-squad'
+    );
+    expect(screen.getByText('While attached, this model shares their fate.')).toBeInTheDocument();
+  });
+
+  it('falls back to formatted slug when target datasheet is missing', () => {
+    const leaderDatasheet = createMockDatasheet({
+      leaderHead: '<p>Attach to the following:</p>',
+      leaderFooter: '',
+      leaders: [
+        {
+          id: 'reivers',
+          slug: 'reiver-squad'
+        }
+      ]
+    });
+
+    render(
+      <MemoryRouter>
+        <DatasheetLeaderRules
+          datasheet={leaderDatasheet}
+          factionDatasheets={[leaderDatasheet]}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Reiver Squad')).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/pages/datasheet/components/datasheet-leader-rules.tsx
+++ b/packages/web/src/pages/datasheet/components/datasheet-leader-rules.tsx
@@ -1,0 +1,115 @@
+import type { FC } from 'react';
+import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import type { depot } from '@depot/core';
+
+import { Card } from '@/components/ui';
+
+interface DatasheetLeaderRulesProps {
+  datasheet: depot.Datasheet;
+  factionDatasheets: depot.Datasheet[];
+}
+
+interface LeaderTarget {
+  key: string;
+  name: string;
+  path?: string;
+}
+
+const formatLeaderName = (slug: string, fallback: string) => {
+  if (!slug) {
+    return fallback;
+  }
+
+  return slug
+    .split('-')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+};
+
+const DatasheetLeaderRules: FC<DatasheetLeaderRulesProps> = ({ datasheet, factionDatasheets }) => {
+  const { leaderHead, leaderFooter, leaders } = datasheet;
+
+  const leaderTargets = useMemo<LeaderTarget[]>(() => {
+    if (!leaders.length) {
+      return [];
+    }
+
+    const targets = new Map<string, LeaderTarget>();
+
+    leaders.forEach((leader) => {
+      const key = leader.slug || leader.id;
+      if (!key || targets.has(key)) {
+        return;
+      }
+
+      const match = factionDatasheets.find(
+        (candidate) => candidate.id === leader.id || candidate.slug === leader.slug
+      );
+
+      const name = match?.name || formatLeaderName(leader.slug, leader.id);
+      const factionSlug = match?.factionSlug || datasheet.factionSlug;
+      const slug = match?.slug || leader.slug;
+
+      targets.set(key, {
+        key,
+        name,
+        path: slug ? `/faction/${factionSlug}/datasheet/${slug}` : undefined
+      });
+    });
+
+    return Array.from(targets.values());
+  }, [datasheet.factionSlug, factionDatasheets, leaders]);
+
+  const hasLeaderContent = Boolean(
+    leaderHead?.trim() || leaderFooter?.trim() || leaderTargets.length
+  );
+
+  if (!hasLeaderContent) {
+    return null;
+  }
+
+  return (
+    <Card className="flex flex-col gap-3 p-4" data-testid="datasheet-leader-rules">
+      {leaderHead?.trim() ? (
+        <div
+          className="text-sm text-gray-700 dark:text-gray-300 [&_p]:m-0"
+          dangerouslySetInnerHTML={{ __html: leaderHead }}
+        />
+      ) : null}
+
+      {leaderTargets.length ? (
+        <ul className="list-disc space-y-1 pl-5">
+          {leaderTargets.map((target) => (
+            <li
+              key={target.key}
+              className="text-sm text-gray-700 dark:text-gray-300"
+              data-testid="leader-target"
+            >
+              {target.path ? (
+                <Link
+                  to={target.path}
+                  className="text-primary-600 hover:underline focus:underline dark:text-primary-400"
+                >
+                  {target.name}
+                </Link>
+              ) : (
+                target.name
+              )}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {leaderFooter?.trim() ? (
+        <div
+          className="text-sm text-gray-700 dark:text-gray-300 [&_p]:m-0"
+          dangerouslySetInnerHTML={{ __html: leaderFooter }}
+        />
+      ) : null}
+    </Card>
+  );
+};
+
+export default DatasheetLeaderRules;

--- a/packages/web/src/pages/datasheet/components/datasheet-profile.test.tsx
+++ b/packages/web/src/pages/datasheet/components/datasheet-profile.test.tsx
@@ -12,6 +12,10 @@ vi.mock('./datasheet-wargear', () => ({
   default: () => <div data-testid="datasheet-wargear">Wargear</div>
 }));
 
+vi.mock('./datasheet-leader-rules', () => ({
+  default: () => <div data-testid="datasheet-leader-rules">Leader Rules</div>
+}));
+
 describe('DatasheetProfile', () => {
   it('renders core and unit abilities as tags', () => {
     const datasheet = createMockDatasheet({
@@ -35,7 +39,7 @@ describe('DatasheetProfile', () => {
       ]
     });
 
-    render(<DatasheetProfile datasheet={datasheet} />);
+    render(<DatasheetProfile datasheet={datasheet} factionDatasheets={[datasheet]} />);
 
     expect(screen.getAllByText(/click a tag to view full rules/i)).toHaveLength(2);
     expect(screen.getByTestId('core-abilities')).toBeInTheDocument();
@@ -59,7 +63,7 @@ describe('DatasheetProfile', () => {
       ]
     });
 
-    render(<DatasheetProfile datasheet={datasheet} />);
+    render(<DatasheetProfile datasheet={datasheet} factionDatasheets={[datasheet]} />);
 
     expect(screen.queryByTestId('core-abilities')).not.toBeInTheDocument();
     expect(screen.getByTestId('unit-abilities')).toBeInTheDocument();

--- a/packages/web/src/pages/datasheet/components/datasheet-profile.tsx
+++ b/packages/web/src/pages/datasheet/components/datasheet-profile.tsx
@@ -4,6 +4,7 @@ import type { depot } from '@depot/core';
 // components
 import DatasheetHero from './datasheet-hero';
 import DatasheetWargear from './datasheet-wargear';
+import DatasheetLeaderRules from './datasheet-leader-rules';
 import { DatasheetAbilities } from '@/components/shared/datasheet';
 
 // utils
@@ -11,9 +12,10 @@ import { categorizeAbilities } from '@/utils/abilities';
 
 interface DatasheetProfileProps {
   datasheet: depot.Datasheet;
+  factionDatasheets: depot.Datasheet[];
 }
 
-const DatasheetProfile: React.FC<DatasheetProfileProps> = ({ datasheet }) => {
+const DatasheetProfile: React.FC<DatasheetProfileProps> = ({ datasheet, factionDatasheets }) => {
   const { inline: inlineAbilities, referenced: coreAbilities } = useMemo(() => {
     return categorizeAbilities(datasheet.abilities);
   }, [datasheet.abilities]);
@@ -22,6 +24,7 @@ const DatasheetProfile: React.FC<DatasheetProfileProps> = ({ datasheet }) => {
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-2" data-testid="datasheet-profile">
         <DatasheetHero datasheet={datasheet} />
+        <DatasheetLeaderRules datasheet={datasheet} factionDatasheets={factionDatasheets} />
         <DatasheetAbilities
           title="Core Abilities"
           abilities={coreAbilities}

--- a/packages/web/src/pages/datasheet/index.tsx
+++ b/packages/web/src/pages/datasheet/index.tsx
@@ -132,7 +132,7 @@ const DatasheetPage: FC = () => {
           data-testid="datasheet-header"
         />
 
-        <DatasheetProfile datasheet={datasheet} />
+        <DatasheetProfile datasheet={datasheet} factionDatasheets={faction.datasheets} />
       </div>
     </AppLayout>
   );

--- a/packages/web/src/pages/edit-roster-unit/index.tsx
+++ b/packages/web/src/pages/edit-roster-unit/index.tsx
@@ -235,6 +235,7 @@ const EditRosterUnitView: React.FC = () => {
         <DatasheetComposition
           composition={unit.datasheet.unitComposition}
           loadout={unit.datasheet.loadout}
+          transport={unit.datasheet.transport}
           data-testid="unit-composition"
         />
 


### PR DESCRIPTION
## Summary
- render datasheet transport capacity alongside unit composition and loadout
- surface leader attachment rules with links to allowed units on the datasheet page
- cover leader rendering with unit tests and ensure roster editing view forwards transport info

## Testing
- pnpm format
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e190ee173c8326b981b2fa708481a3